### PR TITLE
chore: refactor inheritance to composition

### DIFF
--- a/anaplan_sdk/_async_clients/_alm.py
+++ b/anaplan_sdk/_async_clients/_alm.py
@@ -1,5 +1,4 @@
 import logging
-from asyncio import sleep
 from typing import Literal, overload
 
 from anaplan_sdk._base import _AsyncHttpService
@@ -17,9 +16,8 @@ logger = logging.getLogger("anaplan_sdk")
 
 
 class _AsyncAlmClient:
-    def __init__(self, http: _AsyncHttpService, model_id: str, status_poll_delay: int) -> None:
+    def __init__(self, http: _AsyncHttpService, model_id: str) -> None:
         self._http = http
-        self.status_poll_delay = status_poll_delay
         self._model_id = model_id
         self._url = f"https://api.anaplan.com/2/0/models/{model_id}"
 
@@ -129,8 +127,7 @@ class _AsyncAlmClient:
         )
         if not wait_for_completion:
             return task
-        while (task := await self.get_sync_task(task.id)).task_state != "COMPLETE":
-            await sleep(self.status_poll_delay)
+        task = await self._http.poll_task(self.get_sync_task, task.id)
         if not task.result.successful:
             msg = f"Sync task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)
@@ -178,8 +175,7 @@ class _AsyncAlmClient:
         )
         if not wait_for_completion:
             return task
-        while (task := await self.get_comparison_report_task(task.id)).task_state != "COMPLETE":
-            await sleep(self.status_poll_delay)
+        task = await self._http.poll_task(self.get_comparison_report_task, task.id)
         if not task.result.successful:
             msg = f"Comparison Report task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)
@@ -254,8 +250,7 @@ class _AsyncAlmClient:
         )
         if not wait_for_completion:
             return task
-        while (task := await self.get_comparison_summary_task(task.id)).task_state != "COMPLETE":
-            await sleep(self.status_poll_delay)
+        task = await self._http.poll_task(self.get_comparison_summary_task, task.id)
         if not task.result.successful:
             msg = f"Comparison Summary task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)

--- a/anaplan_sdk/_async_clients/_alm.py
+++ b/anaplan_sdk/_async_clients/_alm.py
@@ -2,9 +2,7 @@ import logging
 from asyncio import sleep
 from typing import Literal, overload
 
-import httpx
-
-from anaplan_sdk._base import _AsyncBaseClient
+from anaplan_sdk._base import _AsyncHttpService
 from anaplan_sdk.exceptions import AnaplanActionError
 from anaplan_sdk.models import (
     ModelRevision,
@@ -18,19 +16,12 @@ from anaplan_sdk.models import (
 logger = logging.getLogger("anaplan_sdk")
 
 
-class _AsyncAlmClient(_AsyncBaseClient):
-    def __init__(
-        self,
-        client: httpx.AsyncClient,
-        model_id: str,
-        retry_count: int,
-        page_size: int,
-        status_poll_delay: int,
-    ) -> None:
+class _AsyncAlmClient:
+    def __init__(self, http: _AsyncHttpService, model_id: str, status_poll_delay: int) -> None:
+        self._http = http
         self.status_poll_delay = status_poll_delay
         self._model_id = model_id
         self._url = f"https://api.anaplan.com/2/0/models/{model_id}"
-        super().__init__(client, retry_count=retry_count, page_size=page_size)
 
     async def change_model_status(self, status: Literal["online", "offline"]) -> None:
         """
@@ -38,14 +29,14 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param status: The status of the model. Can be either "online" or "offline".
         """
         logger.info(f"Changed model status to '{status}' for model {self._model_id}.")
-        await self._put(f"{self._url}/onlineStatus", json={"status": status})
+        await self._http.put(f"{self._url}/onlineStatus", json={"status": status})
 
     async def get_revisions(self) -> list[Revision]:
         """
         Use this call to return a list of revisions for a specific model.
         :return: A list of revisions for a specific model.
         """
-        res = await self._get(f"{self._url}/alm/revisions")
+        res = await self._http.get(f"{self._url}/alm/revisions")
         return [Revision.model_validate(e) for e in res.get("revisions", [])]
 
     async def get_latest_revision(self) -> Revision | None:
@@ -57,7 +48,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         latest revision.
         :return: The latest revision for a specific model, or None if no revisions exist.
         """
-        res = (await self._get(f"{self._url}/alm/latestRevision")).get("revisions")
+        res = (await self._http.get(f"{self._url}/alm/latestRevision")).get("revisions")
         return Revision.model_validate(res[0]) if res else None
 
     async def get_syncable_revisions(self, source_model_id: str) -> list[Revision]:
@@ -70,7 +61,9 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param source_model_id: The ID of the source model.
         :return: A list of revisions that can be synchronized to the target model.
         """
-        res = await self._get(f"{self._url}/alm/syncableRevisions?sourceModelId={source_model_id}")
+        res = await self._http.get(
+            f"{self._url}/alm/syncableRevisions?sourceModelId={source_model_id}"
+        )
         return [Revision.model_validate(e) for e in res.get("revisions", [])]
 
     async def create_revision(self, name: str, description: str) -> Revision:
@@ -80,7 +73,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param description: The description of the revision.
         :return: The created Revision Info.
         """
-        res = await self._post(
+        res = await self._http.post(
             f"{self._url}/alm/revisions", json={"name": name, "description": description}
         )
         rev = Revision.model_validate(res["revision"])
@@ -93,7 +86,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         they completed within the last 48 hours.
         :return: A list of sync tasks in descending order of creation time.
         """
-        res = await self._get(f"{self._url}/alm/syncTasks")
+        res = await self._http.get(f"{self._url}/alm/syncTasks")
         return [TaskSummary.model_validate(e) for e in res.get("tasks", [])]
 
     async def get_sync_task(self, task_id: str) -> SyncTask:
@@ -102,7 +95,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param task_id: The ID of the sync task.
         :return: The sync task information.
         """
-        res = await self._get(f"{self._url}/alm/syncTasks/{task_id}")
+        res = await self._http.get(f"{self._url}/alm/syncTasks/{task_id}")
         return SyncTask.model_validate(res["task"])
 
     async def sync_models(
@@ -128,7 +121,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = await self._post(f"{self._url}/alm/syncTasks", json=payload)
+        res = await self._http.post(f"{self._url}/alm/syncTasks", json=payload)
         task = await self.get_sync_task(res["task"]["taskId"])
         logger.info(
             f"Started sync task '{task.id}' from Model '{source_model_id}' "
@@ -152,7 +145,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param revision_id: The ID of the revision.
         :return: A list of models that had a specific revision applied to them.
         """
-        res = await self._get(f"{self._url}/alm/revisions/{revision_id}/appliedToModels")
+        res = await self._http.get(f"{self._url}/alm/revisions/{revision_id}/appliedToModels")
         return [ModelRevision.model_validate(e) for e in res.get("appliedToModels", [])]
 
     async def create_comparison_report(
@@ -177,7 +170,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = await self._post(f"{self._url}/alm/comparisonReportTasks", json=payload)
+        res = await self._http.post(f"{self._url}/alm/comparisonReportTasks", json=payload)
         task = await self.get_comparison_report_task(res["task"]["taskId"])
         logger.info(
             f"Started Comparison Report task '{task.id}' between Model '{source_model_id}' "
@@ -200,7 +193,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param task_id: The ID of the comparison report task.
         :return: The report task information.
         """
-        res = await self._get(f"{self._url}/alm/comparisonReportTasks/{task_id}")
+        res = await self._http.get(f"{self._url}/alm/comparisonReportTasks/{task_id}")
         return ReportTask.model_validate(res["task"])
 
     async def get_comparison_report(self, task: ReportTask) -> bytes:
@@ -209,7 +202,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param task: The report task object containing the task ID.
         :return: The binary content of the comparison report.
         """
-        return await self._get_binary(
+        return await self._http.get_binary(
             f"{self._url}/alm/comparisonReports/"
             f"{task.result.target_revision_id}/{task.result.source_revision_id}"
         )
@@ -253,7 +246,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = await self._post(f"{self._url}/alm/summaryReportTasks", json=payload)
+        res = await self._http.post(f"{self._url}/alm/summaryReportTasks", json=payload)
         task = await self.get_comparison_summary_task(res["task"]["taskId"])
         logger.info(
             f"Started Comparison Summary task '{task.id}' between Model '{source_model_id}' "
@@ -276,7 +269,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param task_id: The ID of the comparison summary task.
         :return: The report task information.
         """
-        res = await self._get(f"{self._url}/alm/summaryReportTasks/{task_id}")
+        res = await self._http.get(f"{self._url}/alm/summaryReportTasks/{task_id}")
         return ReportTask.model_validate(res["task"])
 
     async def get_comparison_summary(self, task: ReportTask) -> SummaryReport:
@@ -285,7 +278,7 @@ class _AsyncAlmClient(_AsyncBaseClient):
         :param task: The summary task object containing the task ID.
         :return: The binary content of the comparison summary.
         """
-        res = await self._get(
+        res = await self._http.get(
             f"{self._url}/alm/summaryReports/"
             f"{task.result.target_revision_id}/{task.result.source_revision_id}"
         )

--- a/anaplan_sdk/_async_clients/_alm.py
+++ b/anaplan_sdk/_async_clients/_alm.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Literal, overload
 
-from anaplan_sdk._base import _AsyncHttpService
+from anaplan_sdk._services import _AsyncHttpService
 from anaplan_sdk.exceptions import AnaplanActionError
 from anaplan_sdk.models import (
     ModelRevision,

--- a/anaplan_sdk/_async_clients/_audit.py
+++ b/anaplan_sdk/_async_clients/_audit.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from anaplan_sdk._base import _AsyncHttpService
+from anaplan_sdk._services import _AsyncHttpService
 from anaplan_sdk.models import User
 
 Event = Literal["all", "byok", "user_activity"]

--- a/anaplan_sdk/_async_clients/_bulk.py
+++ b/anaplan_sdk/_async_clients/_bulk.py
@@ -7,7 +7,7 @@ import httpx
 from typing_extensions import Self
 
 from anaplan_sdk._auth import _create_auth
-from anaplan_sdk._base import _AsyncBaseClient, action_url
+from anaplan_sdk._base import _AsyncHttpService, action_url
 from anaplan_sdk.exceptions import AnaplanActionError, InvalidIdentifierException
 from anaplan_sdk.models import (
     Action,
@@ -30,7 +30,7 @@ from ._transactional import _AsyncTransactionalClient
 logger = logging.getLogger("anaplan_sdk")
 
 
-class AsyncClient(_AsyncBaseClient):
+class AsyncClient:
     """
     Asynchronous Anaplan Client. For guides and examples
     refer to https://vinzenzklass.github.io/anaplan-sdk.
@@ -116,26 +116,21 @@ class AsyncClient(_AsyncBaseClient):
             timeout=timeout,
             **httpx_kwargs,
         )
+        self._http = _AsyncHttpService(_client, retry_count, page_size)
         self._workspace_id = workspace_id
         self._model_id = model_id
-        self._retry_count = retry_count
         self._url = f"https://api.anaplan.com/2/0/workspaces/{workspace_id}/models/{model_id}"
         self._transactional_client = (
-            _AsyncTransactionalClient(_client, model_id, retry_count, page_size)
-            if model_id
-            else None
+            _AsyncTransactionalClient(self._http, model_id) if model_id else None
         )
         self._alm_client = (
-            _AsyncAlmClient(_client, model_id, self._retry_count, status_poll_delay, page_size)
-            if model_id
-            else None
+            _AsyncAlmClient(self._http, model_id, status_poll_delay) if model_id else None
         )
-        self._audit = _AsyncAuditClient(_client, self._retry_count, page_size)
-        self._cloud_works = _AsyncCloudWorksClient(_client, self._retry_count, page_size)
+        self._audit = _AsyncAuditClient(self._http)
+        self._cloud_works = _AsyncCloudWorksClient(self._http)
         self.status_poll_delay = status_poll_delay
         self.upload_chunk_size = upload_chunk_size
         self.allow_file_creation = allow_file_creation
-        super().__init__(_client, retry_count, page_size)
 
     @classmethod
     def from_existing(
@@ -163,15 +158,9 @@ class AsyncClient(_AsyncBaseClient):
             f"with workspace_id={new_ws_id}, model_id={new_model_id}."
         )
         client._url = f"https://api.anaplan.com/2/0/workspaces/{new_ws_id}/models/{new_model_id}"
-        client._transactional_client = _AsyncTransactionalClient(
-            existing._client, new_model_id, existing._retry_count, existing._page_size
-        )
+        client._transactional_client = _AsyncTransactionalClient(existing._http, new_model_id)
         client._alm_client = _AsyncAlmClient(
-            existing._client,
-            new_model_id,
-            existing._retry_count,
-            existing.status_poll_delay,
-            existing._page_size,
+            existing._http, new_model_id, existing.status_poll_delay
         )
         return client
 
@@ -244,7 +233,7 @@ class AsyncClient(_AsyncBaseClient):
             params["s"] = search_pattern
         return [
             Workspace.model_validate(e)
-            for e in await self._get_paginated(
+            for e in await self._http.get_paginated(
                 "https://api.anaplan.com/2/0/workspaces", "workspaces", params=params
             )
         ]
@@ -263,7 +252,7 @@ class AsyncClient(_AsyncBaseClient):
             params["s"] = search_pattern
         return [
             Model.model_validate(e)
-            for e in await self._get_paginated(
+            for e in await self._http.get_paginated(
                 "https://api.anaplan.com/2/0/models", "models", params=params
             )
         ]
@@ -276,7 +265,7 @@ class AsyncClient(_AsyncBaseClient):
         :return:
         """
         logger.info(f"Deleting Models: {', '.join(model_ids)}.")
-        res = await self._post(
+        res = await self._http.post(
             f"https://api.anaplan.com/2/0/workspaces/{self._workspace_id}/bulkDeleteModels",
             json={"modelIdsToDelete": model_ids},
         )
@@ -288,7 +277,8 @@ class AsyncClient(_AsyncBaseClient):
         :return: The List of Files.
         """
         return [
-            File.model_validate(e) for e in await self._get_paginated(f"{self._url}/files", "files")
+            File.model_validate(e)
+            for e in await self._http.get_paginated(f"{self._url}/files", "files")
         ]
 
     async def get_actions(self) -> list[Action]:
@@ -300,7 +290,7 @@ class AsyncClient(_AsyncBaseClient):
         """
         return [
             Action.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}/actions", "actions")
+            for e in await self._http.get_paginated(f"{self._url}/actions", "actions")
         ]
 
     async def get_processes(self) -> list[Process]:
@@ -310,7 +300,7 @@ class AsyncClient(_AsyncBaseClient):
         """
         return [
             Process.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}/processes", "processes")
+            for e in await self._http.get_paginated(f"{self._url}/processes", "processes")
         ]
 
     async def get_imports(self) -> list[Import]:
@@ -320,7 +310,7 @@ class AsyncClient(_AsyncBaseClient):
         """
         return [
             Import.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}/imports", "imports")
+            for e in await self._http.get_paginated(f"{self._url}/imports", "imports")
         ]
 
     async def get_exports(self) -> list[Export]:
@@ -330,7 +320,7 @@ class AsyncClient(_AsyncBaseClient):
         """
         return [
             Export.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}/exports", "exports")
+            for e in await self._http.get_paginated(f"{self._url}/exports", "exports")
         ]
 
     async def run_action(self, action_id: int, wait_for_completion: bool = True) -> TaskStatus:
@@ -345,7 +335,9 @@ class AsyncClient(_AsyncBaseClient):
                until the task is complete. If False, it will spawn the task and return immediately.
         """
         body = {"localeName": "en_US"}
-        res = await self._post(f"{self._url}/{action_url(action_id)}/{action_id}/tasks", json=body)
+        res = await self._http.post(
+            f"{self._url}/{action_url(action_id)}/{action_id}/tasks", json=body
+        )
         task_id = res["task"]["taskId"]
         logger.info(f"Invoked Action '{action_id}', spawned Task: '{task_id}'.")
 
@@ -371,11 +363,11 @@ class AsyncClient(_AsyncBaseClient):
         chunk_count = await self._file_pre_check(file_id)
         logger.info(f"File {file_id} has {chunk_count} chunks.")
         if chunk_count <= 1:
-            return await self._get_binary(f"{self._url}/files/{file_id}")
+            return await self._http.get_binary(f"{self._url}/files/{file_id}")
         return b"".join(
             await gather(
                 *(
-                    self._get_binary(f"{self._url}/files/{file_id}/chunks/{i}")
+                    self._http.get_binary(f"{self._url}/files/{file_id}/chunks/{i}")
                     for i in range(chunk_count)
                 )
             )
@@ -395,13 +387,13 @@ class AsyncClient(_AsyncBaseClient):
         chunk_count = await self._file_pre_check(file_id)
         logger.info(f"File {file_id} has {chunk_count} chunks.")
         if chunk_count <= 1:
-            yield await self._get_binary(f"{self._url}/files/{file_id}")
+            yield await self._http.get_binary(f"{self._url}/files/{file_id}")
             return
 
         for batch_start in range(0, chunk_count, batch_size):
             batch_chunks = await gather(
                 *(
-                    self._get_binary(f"{self._url}/files/{file_id}/chunks/{i}")
+                    self._http.get_binary(f"{self._url}/files/{file_id}/chunks/{i}")
                     for i in range(batch_start, min(batch_start + batch_size, chunk_count))
                 )
             )
@@ -477,7 +469,7 @@ class AsyncClient(_AsyncBaseClient):
             logger.info(
                 f"Completed final upload stream batch of size {len(tasks)} for file {file_id}."
             )
-        await self._post(f"{self._url}/files/{file_id}/complete", json={"id": file_id})
+        await self._http.post(f"{self._url}/files/{file_id}/complete", json={"id": file_id})
         logger.info(f"Completed upload stream for '{file_id}'.")
 
     async def upload_and_import(
@@ -516,7 +508,7 @@ class AsyncClient(_AsyncBaseClient):
         """
         return [
             TaskSummary.model_validate(e)
-            for e in await self._get_paginated(
+            for e in await self._http.get_paginated(
                 f"{self._url}/{action_url(action_id)}/{action_id}/tasks", "tasks"
             )
         ]
@@ -530,7 +522,9 @@ class AsyncClient(_AsyncBaseClient):
         """
         return TaskStatus.model_validate(
             (
-                await self._get(f"{self._url}/{action_url(action_id)}/{action_id}/tasks/{task_id}")
+                await self._http.get(
+                    f"{self._url}/{action_url(action_id)}/{action_id}/tasks/{task_id}"
+                )
             ).get("task")
         )
 
@@ -541,7 +535,7 @@ class AsyncClient(_AsyncBaseClient):
         :param task_id: The Task identifier, sometimes also referred to as the Correlation Id.
         :return: The content of the solution logs.
         """
-        return await self._get_binary(
+        return await self._http.get_binary(
             f"{self._url}/optimizeActions/{action_id}/tasks/{task_id}/solutionLogs"
         )
 
@@ -552,7 +546,7 @@ class AsyncClient(_AsyncBaseClient):
         return file.chunk_count
 
     async def _upload_chunk(self, file_id: int, index: int, chunk: str | bytes) -> None:
-        await self._put_binary_gzip(f"{self._url}/files/{file_id}/chunks/{index}", chunk)
+        await self._http.put_binary_gzip(f"{self._url}/files/{file_id}/chunks/{index}", chunk)
         logger.debug(f"Chunk {index} loaded to file '{file_id}'.")
 
     async def _set_chunk_count(self, file_id: int, num_chunks: int) -> None:
@@ -562,7 +556,9 @@ class AsyncClient(_AsyncBaseClient):
                 "to avoid this error, set `allow_file_creation=True` on the calling instance. "
                 "Make sure you have understood the implications of this before doing so. "
             )
-        response = await self._post(f"{self._url}/files/{file_id}", json={"chunkCount": num_chunks})
+        response = await self._http.post(
+            f"{self._url}/files/{file_id}", json={"chunkCount": num_chunks}
+        )
         optionally_new_file = int(response.get("file").get("id"))
         if optionally_new_file != file_id:
             if self.allow_file_creation:

--- a/anaplan_sdk/_async_clients/_bulk.py
+++ b/anaplan_sdk/_async_clients/_bulk.py
@@ -7,7 +7,7 @@ import httpx
 from typing_extensions import Self
 
 from anaplan_sdk._auth import _create_auth
-from anaplan_sdk._base import _AsyncHttpService, action_url
+from anaplan_sdk._services import _AsyncHttpService, action_url
 from anaplan_sdk.exceptions import AnaplanActionError, InvalidIdentifierException
 from anaplan_sdk.models import (
     Action,

--- a/anaplan_sdk/_async_clients/_bulk.py
+++ b/anaplan_sdk/_async_clients/_bulk.py
@@ -334,7 +334,7 @@ class AsyncClient:
             return TaskStatus.model_validate(await self.get_task_status(action_id, task_id))
         status = await self._http.poll_task(self.get_task_status, action_id, task_id)
         if status.task_state == "COMPLETE" and not status.result.successful:
-            logger.error(f"Task '{task_id}' completed with errors: {status.result.error_message}")
+            logger.error(f"Task '{task_id}' completed with errors.")
             raise AnaplanActionError(f"Task '{task_id}' completed with errors.")
 
         logger.info(f"Task '{task_id}' of '{action_id}' completed successfully.")

--- a/anaplan_sdk/_async_clients/_cloud_works.py
+++ b/anaplan_sdk/_async_clients/_cloud_works.py
@@ -1,10 +1,8 @@
 import logging
 from typing import Any, Literal
 
-import httpx
-
 from anaplan_sdk._base import (
-    _AsyncBaseClient,
+    _AsyncHttpService,
     connection_body_payload,
     construct_payload,
     integration_payload,
@@ -31,11 +29,11 @@ from ._cw_flow import _AsyncFlowClient
 logger = logging.getLogger("anaplan_sdk")
 
 
-class _AsyncCloudWorksClient(_AsyncBaseClient):
-    def __init__(self, client: httpx.AsyncClient, retry_count: int, page_size: int) -> None:
+class _AsyncCloudWorksClient:
+    def __init__(self, http: _AsyncHttpService) -> None:
+        self._http = http
         self._url = "https://api.cloudworks.anaplan.com/2/0/integrations"
-        self._flow = _AsyncFlowClient(client, retry_count=retry_count, page_size=page_size)
-        super().__init__(client, retry_count=retry_count, page_size=page_size)
+        self._flow = _AsyncFlowClient(http)
 
     @property
     def flows(self) -> _AsyncFlowClient:
@@ -51,7 +49,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         """
         return [
             Connection.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}/connections", "connections")
+            for e in await self._http.get_paginated(f"{self._url}/connections", "connections")
         ]
 
     async def create_connection(self, con_info: ConnectionInput | dict[str, Any]) -> str:
@@ -62,7 +60,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                against the ConnectionInput model before sending the request.
         :return: The ID of the new connection.
         """
-        res = await self._post(
+        res = await self._http.post(
             f"{self._url}/connections", json=construct_payload(ConnectionInput, con_info)
         )
         connection_id = res["connections"]["connectionId"]
@@ -79,7 +77,9 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                as when initially creating the connection again. If you want to update only some of
                the details, use the `patch_connection` method instead.
         """
-        await self._put(f"{self._url}/connections/{con_id}", json=connection_body_payload(con_info))
+        await self._http.put(
+            f"{self._url}/connections/{con_id}", json=connection_body_payload(con_info)
+        )
 
     async def patch_connection(self, con_id: str, body: dict[str, Any]) -> None:
         """
@@ -88,14 +88,14 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param body: The name and details of the connection. You can pass all the same details as
                when initially creating the connection again, or just any one of them.
         """
-        await self._patch(f"{self._url}/connections/{con_id}", json=body)
+        await self._http.patch(f"{self._url}/connections/{con_id}", json=body)
 
     async def delete_connection(self, con_id: str) -> None:
         """
         Delete an existing connection in CloudWorks.
         :param con_id: The ID of the connection to delete.
         """
-        await self._delete(f"{self._url}/connections/{con_id}")
+        await self._http.delete(f"{self._url}/connections/{con_id}")
         logger.info(f"Deleted connection '{con_id}'.")
 
     async def get_integrations(
@@ -109,7 +109,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         params = {"sortBy": "name" if sort_by_name == "ascending" else "-name"}
         return [
             Integration.model_validate(e)
-            for e in await self._get_paginated(f"{self._url}", "integrations", params=params)
+            for e in await self._http.get_paginated(f"{self._url}", "integrations", params=params)
         ]
 
     async def get_integration(self, integration_id: str) -> SingleIntegration:
@@ -122,7 +122,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :return: The details of the integration, without the integration type.
         """
         return SingleIntegration.model_validate(
-            (await self._get(f"{self._url}/{integration_id}"))["integration"]
+            (await self._http.get(f"{self._url}/{integration_id}"))["integration"]
         )
 
     async def create_integration(
@@ -149,7 +149,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :return: The ID of the new integration.
         """
         json = integration_payload(body)
-        res = await self._post(f"{self._url}", json=json)
+        res = await self._http.post(f"{self._url}", json=json)
         integration_id = res["integration"]["integrationId"]
         logger.info(f"Created integration '{integration_id}'.")
         return integration_id
@@ -165,7 +165,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                of the details, use the `patch_integration` method instead.
         """
         json = integration_payload(body)
-        await self._put(f"{self._url}/{integration_id}", json=json)
+        await self._http.put(f"{self._url}/{integration_id}", json=json)
 
     async def run_integration(self, integration_id: str) -> str:
         """
@@ -173,7 +173,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param integration_id: The ID of the integration to run.
         :return: The ID of the run instance.
         """
-        run_id = (await self._post_empty(f"{self._url}/{integration_id}/run"))["run"]["id"]
+        run_id = (await self._http.post_empty(f"{self._url}/{integration_id}/run"))["run"]["id"]
         logger.info(f"Started integration run '{run_id}' for integration '{integration_id}'.")
         return run_id
 
@@ -182,7 +182,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         Delete an existing integration in CloudWorks.
         :param integration_id: The ID of the integration to delete.
         """
-        await self._delete(f"{self._url}/{integration_id}")
+        await self._http.delete(f"{self._url}/{integration_id}")
         logger.info(f"Deleted integration '{integration_id}'.")
 
     async def get_run_history(self, integration_id: str) -> list[RunSummary]:
@@ -193,9 +193,9 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         """
         return [
             RunSummary.model_validate(e)
-            for e in (await self._get(f"{self._url}/runs/{integration_id}"))["history_of_runs"].get(
-                "runs", []
-            )
+            for e in (await self._http.get(f"{self._url}/runs/{integration_id}"))[
+                "history_of_runs"
+            ].get("runs", [])
         ]
 
     async def get_run_status(self, run_id: str) -> RunStatus:
@@ -204,7 +204,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The details of the run.
         """
-        return RunStatus.model_validate((await self._get(f"{self._url}/run/{run_id}"))["run"])
+        return RunStatus.model_validate((await self._http.get(f"{self._url}/run/{run_id}"))["run"])
 
     async def get_run_error(self, run_id: str) -> RunError | None:
         """
@@ -213,7 +213,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The details of the run error.
         """
-        run = await self._get(f"{self._url}/runerror/{run_id}")
+        run = await self._http.get(f"{self._url}/runerror/{run_id}")
         return RunError.model_validate(run["runs"]) if run.get("runs") else None
 
     async def create_schedule(
@@ -226,7 +226,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                dictionary as per the documentation. If a dictionary is passed, it will be validated
                against the ScheduleInput model before sending the request.
         """
-        await self._post(
+        await self._http.post(
             f"{self._url}/{integration_id}/schedule",
             json=schedule_payload(integration_id, schedule),
         )
@@ -242,7 +242,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                dictionary as per the documentation. If a dictionary is passed, it will be validated
                against the ScheduleInput model before sending the request.
         """
-        await self._put(
+        await self._http.put(
             f"{self._url}/{integration_id}/schedule",
             json=schedule_payload(integration_id, schedule),
         )
@@ -255,14 +255,14 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param integration_id: The ID of the integration to schedule.
         :param status: The status of the schedule. This can be either "enabled" or "disabled".
         """
-        await self._post_empty(f"{self._url}/{integration_id}/schedule/status/{status}")
+        await self._http.post_empty(f"{self._url}/{integration_id}/schedule/status/{status}")
 
     async def delete_schedule(self, integration_id: str) -> None:
         """
         Delete an integration schedule in CloudWorks. A schedule must already exist.
         :param integration_id: The ID of the integration to schedule.
         """
-        await self._delete(f"{self._url}/{integration_id}/schedule")
+        await self._http.delete(f"{self._url}/{integration_id}/schedule")
         logger.info(f"Deleted schedule for integration '{integration_id}'.")
 
     async def get_notification_config(
@@ -282,7 +282,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         if integration_id:
             notification_id = (await self.get_integration(integration_id)).notification_id
         return NotificationConfig.model_validate(
-            (await self._get(f"{self._url}/notification/{notification_id}"))["notifications"]
+            (await self._http.get(f"{self._url}/notification/{notification_id}"))["notifications"]
         )
 
     async def create_notification_config(self, config: NotificationInput | dict[str, Any]) -> str:
@@ -296,7 +296,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                validated against the NotificationConfig model before sending the request.
         :return: The ID of the new notification configuration.
         """
-        res = await self._post(
+        res = await self._http.post(
             f"{self._url}/notification", json=construct_payload(NotificationInput, config)
         )
         notification_id = res["notification"]["notificationId"]
@@ -316,7 +316,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
                a dictionary as per the documentation. If a dictionary is passed, it will be
                validated against the NotificationConfig model before sending the request.
         """
-        await self._put(
+        await self._http.put(
             f"{self._url}/notification/{notification_id}",
             json=construct_payload(NotificationInput, config),
         )
@@ -335,7 +335,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
             raise ValueError("Either notification_id or integration_id must be specified.")
         if integration_id:
             notification_id = (await self.get_integration(integration_id)).notification_id
-        await self._delete(f"{self._url}/notification/{notification_id}")
+        await self._http.delete(f"{self._url}/notification/{notification_id}")
         logger.info(f"Deleted notification configuration '{notification_id}'.")
 
     async def get_import_error_dump(self, run_id: str) -> bytes:
@@ -348,7 +348,7 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The error dump.
         """
-        return await self._get_binary(f"{self._url}/run/{run_id}/dump")
+        return await self._http.get_binary(f"{self._url}/run/{run_id}/dump")
 
     async def get_process_error_dump(self, run_id: str, action_id: int | str) -> bytes:
         """
@@ -358,4 +358,6 @@ class _AsyncCloudWorksClient(_AsyncBaseClient):
         :param action_id: The ID of the action to retrieve. This can be found in the RunError.
         :return: The error dump.
         """
-        return await self._get_binary(f"{self._url}/run/{run_id}/process/import/{action_id}/dumps")
+        return await self._http.get_binary(
+            f"{self._url}/run/{run_id}/process/import/{action_id}/dumps"
+        )

--- a/anaplan_sdk/_async_clients/_cloud_works.py
+++ b/anaplan_sdk/_async_clients/_cloud_works.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Literal
 
-from anaplan_sdk._base import (
+from anaplan_sdk._services import (
     _AsyncHttpService,
     connection_body_payload,
     construct_payload,

--- a/anaplan_sdk/_async_clients/_cw_flow.py
+++ b/anaplan_sdk/_async_clients/_cw_flow.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from anaplan_sdk._base import _AsyncHttpService, construct_payload
+from anaplan_sdk._services import _AsyncHttpService, construct_payload
 from anaplan_sdk.models.flows import Flow, FlowInput, FlowSummary
 
 logger = logging.getLogger("anaplan_sdk")

--- a/anaplan_sdk/_async_clients/_transactional.py
+++ b/anaplan_sdk/_async_clients/_transactional.py
@@ -3,7 +3,7 @@ from asyncio import gather
 from itertools import chain
 from typing import Any, Literal, overload
 
-from anaplan_sdk._base import (
+from anaplan_sdk._services import (
     _AsyncHttpService,
     parse_calendar_response,
     parse_insertion_response,

--- a/anaplan_sdk/_clients/_alm.py
+++ b/anaplan_sdk/_clients/_alm.py
@@ -1,10 +1,7 @@
 import logging
-from time import sleep
 from typing import Literal, overload
 
-import httpx
-
-from anaplan_sdk._base import _BaseClient
+from anaplan_sdk._services import _HttpService
 from anaplan_sdk.exceptions import AnaplanActionError
 from anaplan_sdk.models import (
     ModelRevision,
@@ -18,19 +15,11 @@ from anaplan_sdk.models import (
 logger = logging.getLogger("anaplan_sdk")
 
 
-class _AlmClient(_BaseClient):
-    def __init__(
-        self,
-        client: httpx.Client,
-        model_id: str,
-        retry_count: int,
-        status_poll_delay: int,
-        page_size: int,
-    ) -> None:
-        self.status_poll_delay = status_poll_delay
+class _AlmClient:
+    def __init__(self, http: _HttpService, model_id: str) -> None:
+        self._http = http
         self._model_id = model_id
         self._url = f"https://api.anaplan.com/2/0/models/{model_id}"
-        super().__init__(client, retry_count=retry_count, page_size=page_size)
 
     def change_model_status(self, status: Literal["online", "offline"]) -> None:
         """
@@ -38,14 +27,14 @@ class _AlmClient(_BaseClient):
         :param status: The status of the model. Can be either "online" or "offline".
         """
         logger.info(f"Changed model status to '{status}' for model {self._model_id}.")
-        self._put(f"{self._url}/onlineStatus", json={"status": status})
+        self._http.put(f"{self._url}/onlineStatus", json={"status": status})
 
     def get_revisions(self) -> list[Revision]:
         """
         Use this call to return a list of revisions for a specific model.
         :return: A list of revisions for a specific model.
         """
-        res = self._get(f"{self._url}/alm/revisions")
+        res = self._http.get(f"{self._url}/alm/revisions")
         return [Revision.model_validate(e) for e in res.get("revisions", [])]
 
     def get_latest_revision(self) -> Revision | None:
@@ -57,7 +46,7 @@ class _AlmClient(_BaseClient):
         latest revision.
         :return: The latest revision for a specific model, or None if no revisions exist.
         """
-        res = (self._get(f"{self._url}/alm/latestRevision")).get("revisions")
+        res = (self._http.get(f"{self._url}/alm/latestRevision")).get("revisions")
         return Revision.model_validate(res[0]) if res else None
 
     def get_syncable_revisions(self, source_model_id: str) -> list[Revision]:
@@ -70,7 +59,7 @@ class _AlmClient(_BaseClient):
         :param source_model_id: The ID of the source model.
         :return: A list of revisions that can be synchronized to the target model.
         """
-        res = self._get(f"{self._url}/alm/syncableRevisions?sourceModelId={source_model_id}")
+        res = self._http.get(f"{self._url}/alm/syncableRevisions?sourceModelId={source_model_id}")
         return [Revision.model_validate(e) for e in res.get("revisions", [])]
 
     def create_revision(self, name: str, description: str) -> Revision:
@@ -80,7 +69,7 @@ class _AlmClient(_BaseClient):
         :param description: The description of the revision.
         :return: The created Revision Info.
         """
-        res = self._post(
+        res = self._http.post(
             f"{self._url}/alm/revisions", json={"name": name, "description": description}
         )
         rev = Revision.model_validate(res["revision"])
@@ -93,7 +82,7 @@ class _AlmClient(_BaseClient):
         they completed within the last 48 hours.
         :return: A list of sync tasks in descending order of creation time.
         """
-        res = self._get(f"{self._url}/alm/syncTasks")
+        res = self._http.get(f"{self._url}/alm/syncTasks")
         return [TaskSummary.model_validate(e) for e in res.get("tasks", [])]
 
     def get_sync_task(self, task_id: str) -> SyncTask:
@@ -102,7 +91,7 @@ class _AlmClient(_BaseClient):
         :param task_id: The ID of the sync task.
         :return: The sync task information.
         """
-        res = self._get(f"{self._url}/alm/syncTasks/{task_id}")
+        res = self._http.get(f"{self._url}/alm/syncTasks/{task_id}")
         return SyncTask.model_validate(res["task"])
 
     def sync_models(
@@ -128,7 +117,7 @@ class _AlmClient(_BaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = self._post(f"{self._url}/alm/syncTasks", json=payload)
+        res = self._http.post(f"{self._url}/alm/syncTasks", json=payload)
         task = self.get_sync_task(res["task"]["taskId"])
         logger.info(
             f"Started sync task '{task.id}' from Model '{source_model_id}' "
@@ -136,8 +125,7 @@ class _AlmClient(_BaseClient):
         )
         if not wait_for_completion:
             return task
-        while (task := self.get_sync_task(task.id)).task_state != "COMPLETE":
-            sleep(self.status_poll_delay)
+        task = self._http.poll_task(self.get_sync_task, task.id)
         if not task.result.successful:
             msg = f"Sync task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)
@@ -152,7 +140,7 @@ class _AlmClient(_BaseClient):
         :param revision_id: The ID of the revision.
         :return: A list of models that had a specific revision applied to them.
         """
-        res = self._get(f"{self._url}/alm/revisions/{revision_id}/appliedToModels")
+        res = self._http.get(f"{self._url}/alm/revisions/{revision_id}/appliedToModels")
         return [ModelRevision.model_validate(e) for e in res.get("appliedToModels", [])]
 
     def create_comparison_report(
@@ -177,7 +165,7 @@ class _AlmClient(_BaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = self._post(f"{self._url}/alm/comparisonReportTasks", json=payload)
+        res = self._http.post(f"{self._url}/alm/comparisonReportTasks", json=payload)
         task = self.get_comparison_report_task(res["task"]["taskId"])
         logger.info(
             f"Started Comparison Report task '{task.id}' between Model '{source_model_id}' "
@@ -185,8 +173,7 @@ class _AlmClient(_BaseClient):
         )
         if not wait_for_completion:
             return task
-        while (task := self.get_comparison_report_task(task.id)).task_state != "COMPLETE":
-            sleep(self.status_poll_delay)
+        task = self._http.poll_task(self.get_comparison_report_task, task.id)
         if not task.result.successful:
             msg = f"Comparison Report task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)
@@ -200,7 +187,7 @@ class _AlmClient(_BaseClient):
         :param task_id: The ID of the comparison report task.
         :return: The report task information.
         """
-        res = self._get(f"{self._url}/alm/comparisonReportTasks/{task_id}")
+        res = self._http.get(f"{self._url}/alm/comparisonReportTasks/{task_id}")
         return ReportTask.model_validate(res["task"])
 
     def get_comparison_report(self, task: ReportTask) -> bytes:
@@ -209,7 +196,7 @@ class _AlmClient(_BaseClient):
         :param task: The report task object containing the task ID.
         :return: The binary content of the comparison report.
         """
-        return self._get_binary(
+        return self._http.get_binary(
             f"{self._url}/alm/comparisonReports/"
             f"{task.result.target_revision_id}/{task.result.source_revision_id}"
         )
@@ -253,7 +240,7 @@ class _AlmClient(_BaseClient):
             "sourceModelId": source_model_id,
             "targetRevisionId": target_revision_id,
         }
-        res = self._post(f"{self._url}/alm/summaryReportTasks", json=payload)
+        res = self._http.post(f"{self._url}/alm/summaryReportTasks", json=payload)
         task = self.get_comparison_summary_task(res["task"]["taskId"])
         logger.info(
             f"Started Comparison Summary task '{task.id}' between Model '{source_model_id}' "
@@ -261,8 +248,7 @@ class _AlmClient(_BaseClient):
         )
         if not wait_for_completion:
             return task
-        while (task := self.get_comparison_summary_task(task.id)).task_state != "COMPLETE":
-            sleep(self.status_poll_delay)
+        task = self._http.poll_task(self.get_comparison_summary_task, task.id)
         if not task.result.successful:
             msg = f"Comparison Summary task {task.id} completed with errors: {task.result.error}."
             logger.error(msg)
@@ -276,7 +262,7 @@ class _AlmClient(_BaseClient):
         :param task_id: The ID of the comparison summary task.
         :return: The report task information.
         """
-        res = self._get(f"{self._url}/alm/summaryReportTasks/{task_id}")
+        res = self._http.get(f"{self._url}/alm/summaryReportTasks/{task_id}")
         return ReportTask.model_validate(res["task"])
 
     def get_comparison_summary(self, task: ReportTask) -> SummaryReport:
@@ -285,7 +271,7 @@ class _AlmClient(_BaseClient):
         :param task: The summary task object containing the task ID.
         :return: The binary content of the comparison summary.
         """
-        res = self._get(
+        res = self._http.get(
             f"{self._url}/alm/summaryReports/"
             f"{task.result.target_revision_id}/{task.result.source_revision_id}"
         )

--- a/anaplan_sdk/_clients/_bulk.py
+++ b/anaplan_sdk/_clients/_bulk.py
@@ -130,7 +130,6 @@ class Client:
         self.upload_parallel = upload_parallel
         self.upload_chunk_size = upload_chunk_size
         self.allow_file_creation = allow_file_creation
-        super().__init__(_client, self._retry_count, page_size)
 
     @classmethod
     def from_existing(

--- a/anaplan_sdk/_clients/_cloud_works.py
+++ b/anaplan_sdk/_clients/_cloud_works.py
@@ -1,10 +1,8 @@
 import logging
 from typing import Any, Literal
 
-import httpx
-
-from anaplan_sdk._base import (
-    _BaseClient,
+from anaplan_sdk._services import (
+    _HttpService,
     connection_body_payload,
     construct_payload,
     integration_payload,
@@ -31,11 +29,11 @@ from ._cw_flow import _FlowClient
 logger = logging.getLogger("anaplan_sdk")
 
 
-class _CloudWorksClient(_BaseClient):
-    def __init__(self, client: httpx.Client, retry_count: int, page_size: int) -> None:
+class _CloudWorksClient:
+    def __init__(self, http: _HttpService) -> None:
+        self._http = http
         self._url = "https://api.cloudworks.anaplan.com/2/0/integrations"
-        self._flow = _FlowClient(client, retry_count=retry_count, page_size=page_size)
-        super().__init__(client, retry_count=retry_count, page_size=page_size)
+        self._flow = _FlowClient(self._http)
 
     @property
     def flows(self) -> _FlowClient:
@@ -51,7 +49,7 @@ class _CloudWorksClient(_BaseClient):
         """
         return [
             Connection.model_validate(e)
-            for e in self._get_paginated(f"{self._url}/connections", "connections")
+            for e in self._http.get_paginated(f"{self._url}/connections", "connections")
         ]
 
     def create_connection(self, con_info: ConnectionInput | dict[str, Any]) -> str:
@@ -62,7 +60,7 @@ class _CloudWorksClient(_BaseClient):
                against the ConnectionInput model before sending the request.
         :return: The ID of the new connection.
         """
-        res = self._post(
+        res = self._http.post(
             f"{self._url}/connections", json=construct_payload(ConnectionInput, con_info)
         )
         connection_id = res["connections"]["connectionId"]
@@ -77,7 +75,7 @@ class _CloudWorksClient(_BaseClient):
                as when initially creating the connection again. If you want to update only some of
                the details, use the `patch_connection` method instead.
         """
-        self._put(f"{self._url}/connections/{con_id}", json=connection_body_payload(con_info))
+        self._http.put(f"{self._url}/connections/{con_id}", json=connection_body_payload(con_info))
 
     def patch_connection(self, con_id: str, body: dict[str, Any]) -> None:
         """
@@ -86,14 +84,14 @@ class _CloudWorksClient(_BaseClient):
         :param body: The name and details of the connection. You can pass all the same details as
                when initially creating the connection again, or just any one of them.
         """
-        self._patch(f"{self._url}/connections/{con_id}", json=body)
+        self._http.patch(f"{self._url}/connections/{con_id}", json=body)
 
     def delete_connection(self, con_id: str) -> None:
         """
         Delete an existing connection in CloudWorks.
         :param con_id: The ID of the connection to delete.
         """
-        self._delete(f"{self._url}/connections/{con_id}")
+        self._http.delete(f"{self._url}/connections/{con_id}")
         logger.info(f"Deleted connection '{con_id}'.")
 
     def get_integrations(
@@ -107,7 +105,7 @@ class _CloudWorksClient(_BaseClient):
         params = {"sortBy": "name" if sort_by_name == "ascending" else "-name"}
         return [
             Integration.model_validate(e)
-            for e in self._get_paginated(f"{self._url}", "integrations", params=params)
+            for e in self._http.get_paginated(f"{self._url}", "integrations", params=params)
         ]
 
     def get_integration(self, integration_id: str) -> SingleIntegration:
@@ -120,7 +118,7 @@ class _CloudWorksClient(_BaseClient):
         :return: The details of the integration, without the integration type.
         """
         return SingleIntegration.model_validate(
-            (self._get(f"{self._url}/{integration_id}"))["integration"]
+            (self._http.get(f"{self._url}/{integration_id}"))["integration"]
         )
 
     def create_integration(
@@ -147,7 +145,9 @@ class _CloudWorksClient(_BaseClient):
         :return: The ID of the new integration.
         """
         json = integration_payload(body)
-        integration_id = (self._post(f"{self._url}", json=json))["integration"]["integrationId"]
+        integration_id = (self._http.post(f"{self._url}", json=json))["integration"][
+            "integrationId"
+        ]
         logger.info(f"Created integration '{integration_id}'.")
         return integration_id
 
@@ -162,7 +162,7 @@ class _CloudWorksClient(_BaseClient):
                of the details, use the `patch_integration` method instead.
         """
         json = integration_payload(body)
-        self._put(f"{self._url}/{integration_id}", json=json)
+        self._http.put(f"{self._url}/{integration_id}", json=json)
 
     def run_integration(self, integration_id: str) -> str:
         """
@@ -170,7 +170,7 @@ class _CloudWorksClient(_BaseClient):
         :param integration_id: The ID of the integration to run.
         :return: The ID of the run instance.
         """
-        run_id = (self._post_empty(f"{self._url}/{integration_id}/run"))["run"]["id"]
+        run_id = (self._http.post_empty(f"{self._url}/{integration_id}/run"))["run"]["id"]
         logger.info(f"Started integration run '{run_id}' for integration '{integration_id}'.")
         return run_id
 
@@ -179,7 +179,7 @@ class _CloudWorksClient(_BaseClient):
         Delete an existing integration in CloudWorks.
         :param integration_id: The ID of the integration to delete.
         """
-        self._delete(f"{self._url}/{integration_id}")
+        self._http.delete(f"{self._url}/{integration_id}")
         logger.info(f"Deleted integration '{integration_id}'.")
 
     def get_run_history(self, integration_id: str) -> list[RunSummary]:
@@ -190,7 +190,7 @@ class _CloudWorksClient(_BaseClient):
         """
         return [
             RunSummary.model_validate(e)
-            for e in (self._get(f"{self._url}/runs/{integration_id}"))["history_of_runs"].get(
+            for e in (self._http.get(f"{self._url}/runs/{integration_id}"))["history_of_runs"].get(
                 "runs", []
             )
         ]
@@ -201,7 +201,7 @@ class _CloudWorksClient(_BaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The details of the run.
         """
-        return RunStatus.model_validate((self._get(f"{self._url}/run/{run_id}"))["run"])
+        return RunStatus.model_validate((self._http.get(f"{self._url}/run/{run_id}"))["run"])
 
     def get_run_error(self, run_id: str) -> RunError | None:
         """
@@ -210,7 +210,7 @@ class _CloudWorksClient(_BaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The details of the run error.
         """
-        run = self._get(f"{self._url}/runerror/{run_id}")
+        run = self._http.get(f"{self._url}/runerror/{run_id}")
         return RunError.model_validate(run["runs"]) if run.get("runs") else None
 
     def create_schedule(
@@ -223,7 +223,7 @@ class _CloudWorksClient(_BaseClient):
                dictionary as per the documentation. If a dictionary is passed, it will be validated
                against the ScheduleInput model before sending the request.
         """
-        self._post(
+        self._http.post(
             f"{self._url}/{integration_id}/schedule",
             json=schedule_payload(integration_id, schedule),
         )
@@ -239,7 +239,7 @@ class _CloudWorksClient(_BaseClient):
                dictionary as per the documentation. If a dictionary is passed, it will be validated
                against the ScheduleInput model before sending the request.
         """
-        self._put(
+        self._http.put(
             f"{self._url}/{integration_id}/schedule",
             json=schedule_payload(integration_id, schedule),
         )
@@ -253,7 +253,7 @@ class _CloudWorksClient(_BaseClient):
         :param integration_id: The ID of the integration to schedule.
         :param status: The status of the schedule. This can be either "enabled" or "disabled".
         """
-        self._post_empty(f"{self._url}/{integration_id}/schedule/status/{status}")
+        self._http.post_empty(f"{self._url}/{integration_id}/schedule/status/{status}")
         logger.info(f"Set schedule status to '{status}' for integration '{integration_id}'.")
 
     def delete_schedule(self, integration_id: str) -> None:
@@ -261,7 +261,7 @@ class _CloudWorksClient(_BaseClient):
         Delete an integration schedule in CloudWorks. A schedule must already exist.
         :param integration_id: The ID of the integration to schedule.
         """
-        self._delete(f"{self._url}/{integration_id}/schedule")
+        self._http.delete(f"{self._url}/{integration_id}/schedule")
         logger.info(f"Deleted schedule for integration '{integration_id}'.")
 
     def get_notification_config(
@@ -281,7 +281,7 @@ class _CloudWorksClient(_BaseClient):
         if integration_id:
             notification_id = (self.get_integration(integration_id)).notification_id
         return NotificationConfig.model_validate(
-            (self._get(f"{self._url}/notification/{notification_id}"))["notifications"]
+            (self._http.get(f"{self._url}/notification/{notification_id}"))["notifications"]
         )
 
     def create_notification_config(self, config: NotificationInput | dict[str, Any]) -> str:
@@ -295,7 +295,7 @@ class _CloudWorksClient(_BaseClient):
                validated against the NotificationConfig model before sending the request.
         :return: The ID of the new notification configuration.
         """
-        res = self._post(
+        res = self._http.post(
             f"{self._url}/notification", json=construct_payload(NotificationInput, config)
         )
         notification_id = res["notification"]["notificationId"]
@@ -315,7 +315,7 @@ class _CloudWorksClient(_BaseClient):
                a dictionary as per the documentation. If a dictionary is passed, it will be
                validated against the NotificationConfig model before sending the request.
         """
-        self._put(
+        self._http.put(
             f"{self._url}/notification/{notification_id}",
             json=construct_payload(NotificationInput, config),
         )
@@ -334,7 +334,7 @@ class _CloudWorksClient(_BaseClient):
             raise ValueError("Either notification_id or integration_id must be specified.")
         if integration_id:
             notification_id = (self.get_integration(integration_id)).notification_id
-        self._delete(f"{self._url}/notification/{notification_id}")
+        self._http.delete(f"{self._url}/notification/{notification_id}")
         logger.info(f"Deleted notification configuration '{notification_id}'.")
 
     def get_import_error_dump(self, run_id: str) -> bytes:
@@ -347,7 +347,7 @@ class _CloudWorksClient(_BaseClient):
         :param run_id: The ID of the run to retrieve.
         :return: The error dump.
         """
-        return self._get_binary(f"{self._url}/run/{run_id}/dump")
+        return self._http.get_binary(f"{self._url}/run/{run_id}/dump")
 
     def get_process_error_dump(self, run_id: str, action_id: int | str) -> bytes:
         """
@@ -357,4 +357,4 @@ class _CloudWorksClient(_BaseClient):
         :param action_id: The ID of the action to retrieve. This can be found in the RunError.
         :return: The error dump.
         """
-        return self._get_binary(f"{self._url}/run/{run_id}/process/import/{action_id}/dumps")
+        return self._http.get_binary(f"{self._url}/run/{run_id}/process/import/{action_id}/dumps")

--- a/anaplan_sdk/models/_bulk.py
+++ b/anaplan_sdk/models/_bulk.py
@@ -1,7 +1,6 @@
 from typing import Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, field_validator
-from pydantic.alias_generators import to_camel
+from pydantic import Field, field_validator
 
 from ._base import AnaplanModel
 
@@ -164,13 +163,7 @@ class TaskResult(AnaplanModel):
     )
 
 
-class TaskStatus(AnaplanModel):
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-    id: str = Field(validation_alias="taskId", description="The unique identifier of this task.")
-    task_state: Literal["NOT_STARTED", "IN_PROGRESS", "COMPLETE"] = Field(
-        description="The state of this task."
-    )
-    creation_time: int = Field(description="Unix timestamp of when this task was created.")
+class TaskStatus(TaskSummary):
     progress: float = Field(description="The progress of this task as a float between 0 and 1.")
     current_step: str | None = Field(None, description="The current step of this task.")
     result: TaskResult | None = Field(None)


### PR DESCRIPTION
Like #242 nicely demonstrates, making changes at the lower level is very annoying in the current inheritance hierarchy. We also needlessly instantiate several instances of the base class that stores no state that we need to encapsulate.

We can fix both of these issues by moving to a composition based approach and just inject the http into each client.

