### PR TITLE
draft: easier model switch

### DIFF
--- a/anaplan_sdk/_async_clients/_bulk.py
+++ b/anaplan_sdk/_async_clients/_bulk.py
@@ -170,6 +170,27 @@ class AsyncClient:
         client._alm_client = _AsyncAlmClient(existing._http, new_model_id)
         return client
 
+    def switch_model(self, model_id: str | None = None, workspace_id: str | None = None) -> Self:
+        """
+        Creates a new instance of the Client with the given model and workspace Ids. **This creates
+        a copy of the current client. Do not expect the current instance to reference to new model
+        after calling this method.**
+        :param workspace_id: The workspace Id to use or None to use the existing workspace Id.
+        :param model_id: The model Id to use or None to use the existing model Id.
+        :return: A new instance of the Client.
+        """
+        client = copy(self)
+        new_ws_id = workspace_id or self._workspace_id
+        new_model_id = model_id or self._model_id
+        logger.debug(
+            f"Creating a new AsyncClient from existing instance "
+            f"with workspace_id={new_ws_id}, model_id={new_model_id}."
+        )
+        client._url = f"https://api.anaplan.com/2/0/workspaces/{new_ws_id}/models/{new_model_id}"
+        client._transactional_client = _AsyncTransactionalClient(self._http, new_model_id)
+        client._alm_client = _AsyncAlmClient(self._http, new_model_id)
+        return client
+
     @property
     def audit(self) -> _AsyncAuditClient:
         """

--- a/anaplan_sdk/_clients/_bulk.py
+++ b/anaplan_sdk/_clients/_bulk.py
@@ -175,6 +175,27 @@ class Client:
         client._alm_client = _AlmClient(existing._http, new_model_id)
         return client
 
+    def switch_model(self, model_id: str | None = None, workspace_id: str | None = None) -> Self:
+        """
+        Creates a new instance of the Client with the given model and workspace Ids. **This creates
+        a copy of the current client. Do not expect the current instance to reference to new model
+        after calling this method.**
+        :param workspace_id: The workspace Id to use or None to use the existing workspace Id.
+        :param model_id: The model Id to use or None to use the existing model Id.
+        :return: A new instance of the Client.
+        """
+        client = copy(self)
+        new_ws_id = workspace_id or self._workspace_id
+        new_model_id = model_id or self._model_id
+        logger.debug(
+            f"Creating a new AsyncClient from existing instance "
+            f"with workspace_id={new_ws_id}, model_id={new_model_id}."
+        )
+        client._url = f"https://api.anaplan.com/2/0/workspaces/{new_ws_id}/models/{new_model_id}"
+        client._transactional_client = _TransactionalClient(self._http, new_model_id)
+        client._alm_client = _AlmClient(self._http, new_model_id)
+        return client
+
     @property
     def audit(self) -> _AuditClient:
         """


### PR DESCRIPTION
Working with several models in the current design is verbose and cumbersome. This PR is for ideating a better way.

The current draft is much easier and syntactically nicer, e.g. allows chaining calls:

```python
connections = await anaplan.switch_model("XYZ").cw.get_connections()
```

Much nicer, but this is also a bit of a foot gun. Users may reasonably expect the instance this is invoked on to change and subsequently make call to the new model. We could prevent the worst by disabling the existing client after and thereby prevent erroneous calls, but this then in turn hurts re-usability.

