### PR TITLE
feat: read SCIM user data

### DIFF
--- a/anaplan_sdk/_async_clients/__init__.py
+++ b/anaplan_sdk/_async_clients/__init__.py
@@ -2,6 +2,7 @@ from ._alm import _AsyncAlmClient
 from ._audit import _AsyncAuditClient
 from ._bulk import AsyncClient
 from ._cloud_works import _AsyncCloudWorksClient
+from ._scim import _AsyncScimClient
 from ._transactional import _AsyncTransactionalClient
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "_AsyncAlmClient",
     "_AsyncAuditClient",
     "_AsyncCloudWorksClient",
+    "_AsyncScimClient",
     "_AsyncTransactionalClient",
 ]

--- a/anaplan_sdk/_async_clients/_bulk.py
+++ b/anaplan_sdk/_async_clients/_bulk.py
@@ -24,6 +24,7 @@ from anaplan_sdk.models import (
 from ._alm import _AsyncAlmClient
 from ._audit import _AsyncAuditClient
 from ._cloud_works import _AsyncCloudWorksClient
+from ._scim import _AsyncScimClient
 from ._transactional import _AsyncTransactionalClient
 
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
@@ -117,6 +118,7 @@ class AsyncClient(_AsyncBaseClient):
         )
         self._audit = _AsyncAuditClient(_client, self._retry_count)
         self._cloud_works = _AsyncCloudWorksClient(_client, self._retry_count)
+        self._scim = _AsyncScimClient(_client, self._retry_count)
         self.status_poll_delay = status_poll_delay
         self.upload_chunk_size = upload_chunk_size
         self.allow_file_creation = allow_file_creation
@@ -196,6 +198,13 @@ class AsyncClient(_AsyncBaseClient):
                 "is instantiated correctly with a valid `model_id`."
             )
         return self._alm_client
+
+    @property
+    def scim(self) -> _AsyncScimClient:
+        """
+        The Scim provides access to the Anaplan SCIM API.
+        """
+        return self._scim
 
     async def list_workspaces(self, search_pattern: str | None = None) -> list[Workspace]:
         """

--- a/anaplan_sdk/_async_clients/_scim.py
+++ b/anaplan_sdk/_async_clients/_scim.py
@@ -1,0 +1,75 @@
+from asyncio import gather
+from itertools import chain
+from math import ceil
+from typing import Any, Iterator
+
+import httpx
+
+from anaplan_sdk._base import _AsyncBaseClient
+from anaplan_sdk.models import UserScim
+
+
+class _AsyncScimClient(_AsyncBaseClient):
+    def __init__(self, client: httpx.AsyncClient, retry_count: int) -> None:
+        self._url = "https://api.anaplan.com/scim/1/0/v2/Users"
+        super().__init__(retry_count, client)
+
+    async def get_user(self, user_id: str) -> UserScim:
+        """
+        Use this endpoint to retrieve all user information and associated workspaces.
+        :return: The requested User and their workspace details.
+        """
+        return UserScim.model_validate(await self._get(f"{self._url}/{user_id}"))
+
+    async def list_users(self, filter: str | None = None) -> list[UserScim]:
+        """
+        Use this endpoint to search for users and associated
+        workspaces. Note that the limit is 100 users per call.
+
+        :param filter: Optional filter for users. A filter expression
+               to restrict the result set in the form of
+               <field> <operator> <value>
+               Example: givenName Eq “John”
+               Expressions may be separated with and, or or ( )
+               Supported filter fields include: id, externalId, userName,
+               name.familyName, name.givenName.
+               Supproted operators include: Eq, Ne, Pr, Gt, Ge, Lt, Le
+        :return: The List of Users and their workspace details.
+
+        """
+        params = {"filter": filter} if filter else None
+        return [
+            UserScim.model_validate(e)
+            for e in await self._get_paginated(f"{self._url}", "Resources", params=params)
+        ]
+
+    async def __get_page(
+        self, url: str, limit: int, offset: int, result_key: str, **kwargs
+    ) -> list:
+        """
+        SCIM uses different pagination controls.
+        """
+        kwargs["params"] = kwargs.get("params") or {} | {"count": limit, "startIndex": offset}
+        return (await self._get(url, **kwargs)).get(result_key, [])
+
+    async def __get_first_page(
+        self, url: str, limit: int, result_key: str, **kwargs
+    ) -> tuple[list, int]:
+        kwargs["params"] = kwargs.get("params") or {} | {"count": limit}
+        res = await self._get(url, **kwargs)
+        return res.get(result_key, []), res["totalResults"]
+
+    async def _get_paginated(
+        self, url: str, result_key: str, page_size: int = 5_000, **kwargs
+    ) -> Iterator[dict[str, Any]]:
+        first_page, total_items = await self.__get_first_page(url, page_size, result_key, **kwargs)
+        if total_items <= page_size:
+            return iter(first_page)
+        pages = await gather(
+            *(
+                self.__get_page(url, page_size, n * page_size, result_key, **kwargs)
+                for n in range(1, ceil(total_items / page_size))
+            )
+        )
+
+        return chain(first_page, *pages)

--- a/anaplan_sdk/_clients/__init__.py
+++ b/anaplan_sdk/_clients/__init__.py
@@ -1,6 +1,7 @@
 from ._alm import _AlmClient
 from ._audit import _AuditClient
 from ._bulk import Client
+from ._scim import _ScimClient
 from ._transactional import _TransactionalClient
 
-__all__ = ["Client", "_AlmClient", "_AuditClient", "_TransactionalClient"]
+__all__ = ["Client", "_AlmClient", "_AuditClient", "_ScimClient", "_TransactionalClient"]

--- a/anaplan_sdk/_clients/_bulk.py
+++ b/anaplan_sdk/_clients/_bulk.py
@@ -26,6 +26,7 @@ from anaplan_sdk.models import (
 from ._alm import _AlmClient
 from ._audit import _AuditClient
 from ._cloud_works import _CloudWorksClient
+from ._scim import _ScimClient
 from ._transactional import _TransactionalClient
 
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
@@ -120,6 +121,7 @@ class Client(_BaseClient):
         self._cloud_works = _CloudWorksClient(_client, self._retry_count)
         self._thread_count = multiprocessing.cpu_count()
         self._audit = _AuditClient(_client, self._retry_count, self._thread_count)
+        self._scim = _ScimClient(_client, self._retry_count)
         self.status_poll_delay = status_poll_delay
         self.upload_parallel = upload_parallel
         self.upload_chunk_size = upload_chunk_size
@@ -200,6 +202,13 @@ class Client(_BaseClient):
                 "is instantiated correctly with a valid `model_id`."
             )
         return self._alm_client
+
+    @property
+    def scim(self) -> _ScimClient:
+        """
+        The Scim provides access to the Anaplan SCIM API.
+        """
+        return self._scim
 
     def list_workspaces(self, search_pattern: str | None = None) -> list[Workspace]:
         """

--- a/anaplan_sdk/_clients/_scim.py
+++ b/anaplan_sdk/_clients/_scim.py
@@ -1,0 +1,71 @@
+from concurrent.futures import ThreadPoolExecutor
+from itertools import chain
+from math import ceil
+from typing import Any, Iterator
+
+import httpx
+
+from anaplan_sdk._base import _BaseClient
+from anaplan_sdk.models import UserScim
+
+
+class _ScimClient(_BaseClient):
+    def __init__(self, client: httpx.Client, retry_count: int) -> None:
+        self._url = "https://api.anaplan.com/scim/1/0/v2/Users"
+        super().__init__(retry_count, client)
+
+    def get_user(self, user_id: str) -> UserScim:
+        """
+        Use this endpoint to retrieve all user information and associated workspaces.
+        :return: The requested User and their workspace details.
+        """
+        return UserScim.model_validate(self._get(f"{self._url}/{user_id}"))
+
+    def list_users(self, filter: str | None = None) -> list[UserScim]:
+        """
+        Use this endpoint to search for users and associated
+        workspaces. Note that the limit is 100 users per call.
+
+        :param filter: Optional filter for users. A filter expression
+               to restrict the result set in the form of
+               <field> <operator> <value>
+               Example: givenName Eq “John”
+               Expressions may be separated with and, or or ( )
+               Supported filter fields include: id, externalId, userName,
+               name.familyName, name.givenName.
+               Supproted operators include: Eq, Ne, Pr, Gt, Ge, Lt, Le
+        :return: The List of Users and their workspace details.
+
+        """
+        params = {"filter": filter} if filter else None
+        return [
+            UserScim.model_validate(e)
+            for e in self._get_paginated(f"{self._url}", "Resources", params=params)
+        ]
+
+    def __get_page(self, url: str, limit: int, offset: int, result_key: str, **kwargs) -> list:
+        """
+        SCIM uses different pagination controls.
+        """
+        kwargs["params"] = kwargs.get("params") or {} | {"count": limit, "startIndex": offset}
+        return self._get(url, **kwargs).get(result_key, [])
+
+    def __get_first_page(self, url: str, limit: int, result_key: str, **kwargs) -> tuple[list, int]:
+        kwargs["params"] = kwargs.get("params") or {} | {"count": limit}
+        res = self._get(url, **kwargs)
+        return res.get(result_key, []), res["totalResults"]
+
+    def _get_paginated(
+        self, url: str, result_key: str, page_size: int = 5_000, **kwargs
+    ) -> Iterator[dict[str, Any]]:
+        first_page, total_items = self.__get_first_page(url, page_size, result_key, **kwargs)
+        if total_items <= page_size:
+            return iter(first_page)
+
+        with ThreadPoolExecutor() as executor:
+            pages = executor.map(
+                lambda n: self.__get_page(url, page_size, n * page_size, result_key, **kwargs),
+                range(1, ceil(total_items / page_size)),
+            )
+
+        return chain(first_page, *pages)

--- a/anaplan_sdk/models/__init__.py
+++ b/anaplan_sdk/models/__init__.py
@@ -1,4 +1,5 @@
 from ._alm import ModelRevision, Revision, SyncTask
+from ._scim import Entitlement, UserScim
 from ._base import AnaplanModel
 from ._bulk import (
     Action,
@@ -46,4 +47,6 @@ __all__ = [
     "Failure",
     "InsertionResult",
     "Revision",
+    "Entitlement",
+    "UserScim",
 ]

--- a/anaplan_sdk/models/_scim.py
+++ b/anaplan_sdk/models/_scim.py
@@ -1,0 +1,25 @@
+from pydantic import Field, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from ._base import AnaplanModel
+
+
+class Entitlement(AnaplanModel):
+    value: str = Field(description="Workspace ID(s) or names for this entitlement.")
+    display: str | None = Field(None, description="Optional name of a Workspace.")
+    type: str = Field(description="The type of identifier used as the entitlement value.")
+    primary: bool | None = Field(None, description="First item, ignored by Anaplan.")
+
+
+class UserScim(AnaplanModel):
+    schemas: list = Field(description="Schemas for this user object.")
+    id: str = Field(description="The unique identifier of this revision.")
+    external_id: str | None = Field(
+        None, validation_alias="externalId", description="The unique identifier of this revision."
+    )
+    active: bool = Field(description="True when user is enabled.")
+    user_name: str = Field(validation_alias="userName", description="The name by which this user is known within Anaplan.")
+    meta: dict = Field({}, description="Information about this resource.")
+    name: dict = Field({}, description="The components of users personal name.")
+    display_name: str = Field(validation_alias="displayName", description="The users personal name.")
+    entitlements: list[Entitlement] = Field([], description="The workspaces for this user.")

--- a/tests/async/test_async_scim_client.py
+++ b/tests/async/test_async_scim_client.py
@@ -1,0 +1,14 @@
+from anaplan_sdk import AsyncClient
+
+
+async def test_get_users(client: AsyncClient):
+    users = await client.scim.list_users('name.givenName Eq "Michael"')
+    assert isinstance(users, list)
+    assert len(users) > 0
+
+
+async def test_get_user(client: AsyncClient):
+    me = await client.audit.get_user()
+    user = await client.scim.get_user (me.id)
+    assert user.user_name == me.email
+

--- a/tests/sync/test_scim_client.py
+++ b/tests/sync/test_scim_client.py
@@ -1,0 +1,14 @@
+from anaplan_sdk import Client
+
+
+def test_get_users(client: Client):
+    users = client.scim.list_users('name.givenName Eq "Michael"')
+    assert isinstance(users, list)
+    assert len(users) > 0
+
+
+def test_get_user(client: Client):
+    me = client.audit.get_user()
+    user = client.scim.get_user (me.id)
+    assert user.user_name == me.email
+


### PR DESCRIPTION
This is an initial client for Anaplan SCIM API which can read user data with two methods.

Client.scim.get_user(user_id: str)
Client.scim.list_users(filter: str)
AsyncClient.scim.get_user(user_id: str)
AsyncClient.scim.list_users(filter; str)

Included tests pass.
No documentation is provided other than docstrings and model Field description strings.